### PR TITLE
Tests are outdated + Force Default feature

### DIFF
--- a/lib/gravtastic.rb
+++ b/lib/gravtastic.rb
@@ -29,7 +29,6 @@ module Gravtastic
       :rating =>       'PG',
       :secure =>       true,
       :filetype =>     :png,
-      :forcedefault => false
     }.merge(options)
 
     # The method where Gravtastic get the users' email from defaults to `#email`.

--- a/spec/gravtastic_spec.rb
+++ b/spec/gravtastic_spec.rb
@@ -24,7 +24,6 @@ describe Gravtastic do
         :rating => 'PG',
         :secure => true,
         :filetype => :png,
-        :forcedefault => false
       }
     end
 


### PR DESCRIPTION
- Default value of "secure" was changed in 6c4b1529bf. Tests broke, I repaired them.
- Some time ago Gravatar launched feature that allow to force the default image to always load. Now it's supported.
