### PR TITLE
Add MIT license flag to the gemspec

### DIFF
--- a/gravtastic.gemspec
+++ b/gravtastic.gemspec
@@ -8,6 +8,7 @@ require './lib/gravtastic/version'
   s.author   = 'Chris Lloyd'
   s.email    = 'christopher.lloyd@gmail.com'
   s.homepage = 'http://github.com/chrislloyd/gravtastic'
+  s.license  = 'MIT'
 
   s.summary     = 'A Ruby wrapper for Gravatar URLs'
   s.description = s.summary


### PR DESCRIPTION
I would like to have the license listed in the gemspec because it will make automated license checking easier. 
Looking at the README, the license appears to be MIT.
